### PR TITLE
Fixed button alignment problem

### DIFF
--- a/www/templates/tab-all.html
+++ b/www/templates/tab-all.html
@@ -7,11 +7,11 @@
             <ion-item>
             Calling all widgets!
             </ion-item>
-            <ion-item class="item-button-right" ng-repeat="widget in widgets" href="{{widget.href}}">
+            <ion-item class="item-button-right" ng-repeat="widget in widgets">
                 {{widget.title}}
-                <button class="button button-dark">
+                <a class="button button-dark" href="{{widget.href}}">
                     <i class="icon ion-ios-arrow-forward"></i>
-                </button>
+                </a>
             </ion-item>
         </ion-list>
     </ion-content>


### PR DESCRIPTION
The button linking to the widget was oddly positioned in the middle of
the list item. So I played around with href’s and different tags, and
found a solution!